### PR TITLE
feat: 共通フックの追加

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,8 +4,8 @@ import EstimatePage from './pages/EstimatePage'; // 見積画面に切り替え
 function App() {
   return (
     <div className="App">
-      <ContractPage />
-      {/* <EstimatePage /> */}
+      {/* <ContractPage /> */}
+      <EstimatePage />
     </div>
   );
 }

--- a/src/components/templates/DynamicScreenTemplate.jsx
+++ b/src/components/templates/DynamicScreenTemplate.jsx
@@ -4,7 +4,7 @@ import SectionTable from '../organisms/SectionTable';
 import SectionElement from '../organisms/SectionElement';
 import { layoutStyle } from '../../config/ScreenConfig';
 
-const DynamicScreenTemplate = ({ config, data, handlers, title }) => {
+const DynamicScreenTemplate = ({ config, data, handlers, onDefaultChange, title }) => {
   return (
     <Container className={layoutStyle.containerPadding} fluid style={{ maxWidth: 'fit-content', margin: '0' }}>
       <h3>{title}</h3>
@@ -15,7 +15,7 @@ const DynamicScreenTemplate = ({ config, data, handlers, title }) => {
         if (sectionConfig.sectionType === 'table') {
           return (
             <div key={sectionConfig.id} className={layoutStyle.sectionSpacing}>
-              <SectionTable config={sectionConfig} data={data} handlers={handlers} />
+              <SectionTable config={sectionConfig} data={data} handlers={handlers} onDefaultChange={onDefaultChange} />
             </div>
           );
         }

--- a/src/config/EstimateConfig.jsx
+++ b/src/config/EstimateConfig.jsx
@@ -1,4 +1,4 @@
-import { Form, Button, Badge } from 'react-bootstrap';
+import { Button, Badge } from 'react-bootstrap';
 
 // 見積もり画面用のレイアウト定義
 export const estimateLayoutConfig = [
@@ -47,23 +47,15 @@ export const estimateLayoutConfig = [
       {
         key: 'quantity',
         label: '数量',
-        type: 'element',
+        type: 'input',
+        inputType: 'number',
         headerStyle: { width: '100px' },
-        element: (data, handlers) => (
-          <Form.Control
-            type="number"
-            size="sm"
-            value={data.quantity}
-            onChange={handlers.onQuantityChange}
-            style={{ textAlign: 'right' }}
-          />
-        ),
+        style: { textAlign: 'right' },
       },
       { key: 'unitPrice', label: '単価', type: 'text', headerStyle: { width: '150px' }, style: { textAlign: 'right' } },
       {
         key: 'amount',
         label: '金額',
-        type: 'text',
         headerStyle: { width: '150px' },
         style: { textAlign: 'right', fontWeight: 'bold' },
       },

--- a/src/hooks/useFormHandler.js
+++ b/src/hooks/useFormHandler.js
@@ -1,0 +1,20 @@
+import { useState, useCallback } from 'react';
+
+/**
+ * フォームの状態管理と汎用更新ロジックを提供する共通フック
+ * @param {Object} initialData
+ * @returns {Object} { data, setData, onDefaultChange }
+ */
+export const useFormHandler = (initialData) => {
+  const [data, setData] = useState(initialData);
+
+  // 指定されたキーに対応するStateの値を更新する汎用関数
+  const onDefaultChange = useCallback((key, value) => {
+    setData((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+  }, []);
+
+  return { data, setData, onDefaultChange };
+};

--- a/src/pages/EstimatePage.jsx
+++ b/src/pages/EstimatePage.jsx
@@ -1,11 +1,10 @@
-import { useState } from 'react';
+import { useFormHandler } from '../hooks/useFormHandler';
 import { estimateLayoutConfig } from '../config/EstimateConfig.jsx';
 import DynamicScreenTemplate from '../components/templates/DynamicScreenTemplate';
 
 const EstimatePage = () => {
   // 1. テスト用モックデータ
   const initialData = {
-    // 基本情報
     estimateId: 'EST-2025-001',
     issueDate: '2025/12/03',
     subject: '【テスト案件】社内システム改修工事のお見積り',
@@ -29,37 +28,26 @@ const EstimatePage = () => {
   };
 
   // 状態管理定義
-  const [data, setData] = useState(initialData);
+  const { data, onDefaultChange } = useFormHandler(initialData);
 
   // ハンドラー定義
-  const handleQuantityChange = (e) => {
-    const newQty = e.target.value;
-    console.log('数量変更:', newQty);
-    setData({ ...data, quantity: newQty });
-  };
-
-  const handleSave = () => {
-    alert('見積データを保存しました。\n(これはテスト動作です)');
-  };
-
-  const handleCancel = () => {
-    alert('入力を破棄して戻ります。');
-  };
-
-  // ハンドラーを渡すためのオブジェクトを作成
   const handlers = {
-    onQuantityChange: handleQuantityChange,
-    onSave: handleSave,
-    onCancel: handleCancel,
+    onSave: () => {
+      alert(`保存します:\n${JSON.stringify(data, null, 2)}`);
+    },
+    onCancel: () => {
+      alert('入力を破棄して戻ります。');
+    },
   };
 
   return (
     // prettier-ignore
     <DynamicScreenTemplate
-      title="見積詳細画面"             // 画面構成設定を渡す
-      config={estimateLayoutConfig}   // 画面構成設定を渡す
-      data={data}                     // テストデータを渡す
-      handlers={handlers}             // ロジックを渡す
+      title="見積詳細画面"               // 画面構成設定を渡す
+      config={estimateLayoutConfig}     // 画面構成設定を渡す
+      data={data}                       // テストデータを渡す
+      handlers={handlers}               // ロジックを渡す
+      onDefaultChange={onDefaultChange} // 汎用ハンドラを渡す
     />
   );
 };


### PR DESCRIPTION
- SectionTable に type: 'input' および 'select', 'checkbox' のレンダリングサポートを追加
- フォームの状態管理と汎用的な更新ロジックを分離する useFormHandler フックの実装
- Config内の onChangeKey に基づく個別ハンドラと、onDefaultChange による共通ハンドラの優先順位判定ロジックの導入
- 自作コンポーネントへの置き換えを容易にするため、renderCellContent による描画ロジックの共通化
- 新しいアーキテクチャのデモとして、入力項目を含む「見積詳細画面（EstimatePage）」を構築